### PR TITLE
Attempt to improve editor paste experience

### DIFF
--- a/frontend/src/app/util/quill/index.ts
+++ b/frontend/src/app/util/quill/index.ts
@@ -1,3 +1,3 @@
 export { Divider, dividerHandler } from './divider';
 export { imageHandler } from './image-link';
-export { TextSoftBreakBlot, shiftEnterHandler, brMatcher, textNodeMatcher } from './soft-line-break';
+export { TextSoftBreakBlot, shiftEnterHandler, brMatcher, textNodeMatcher } from './text-soft-break-blot';

--- a/frontend/src/app/util/quill/soft-line-break.ts
+++ b/frontend/src/app/util/quill/soft-line-break.ts
@@ -79,28 +79,26 @@ export function shiftEnterHandler(this: any, range: QuillRange) {
 }
 
 export function brMatcher(node: Node) {
-    if (node.nextSibling && !node.nextSibling.textContent.startsWith('\n')) {
-        return new Delta().insert(LINE_SEPARATOR);
-    } else {
-        // If this node is a <br>, and the next node doesn't exist, 
-        // or is a <br>, just return an empty Delta.
-        // TODO: Is this actually ideal behavior?
-        return new Delta();
-    }
+    // This behavior always interprets a BR as a soft line break,
+    // which means that any lone <br>s will be folded into the next <p> or
+    // (if there is no next paragraph) the previous <p>
+    return new Delta().insert(LINE_SEPARATOR);
 }
 
 export function textNodeMatcher(node: any, delta: any) {
     // This code is almost identical to the default TextMatcher code--
     // just with extra calls to toDeltaText().
     let text = node.data;
+    // Going to comment this out for now--it actually seems to result in 
+    // WORSE imports from external sources (and Word).
     // Word represents empty line with <o:p>&nbsp;</o:p>
-    if (node.parentNode.tagName === 'O:P') {
-        text = toDeltaText(text);
-        return new Delta().insert(text.trim());
-    }
-    if (text.trim().length === 0 && text.includes('\n')) {
-        return new Delta().insert(text);
-    }
+    // if (node.parentNode.tagName === 'O:P') {
+    //     text = toDeltaText(text);
+    //     return new Delta().insert(text.trim());
+    // }
+    // if (text.trim().length === 0 && text.includes('\n')) {
+    //     return new Delta().insert(text);
+    // }
     if (!isPre(node)) {
         const replacer = (collapse, match) => {
             const replaced = match.replace(/[^\u00a0]/g, ''); // \u00a0 is nbsp;

--- a/frontend/src/app/util/quill/text-soft-break-blot.ts
+++ b/frontend/src/app/util/quill/text-soft-break-blot.ts
@@ -96,9 +96,10 @@ export function textNodeMatcher(node: any, delta: any) {
     //     text = toDeltaText(text);
     //     return new Delta().insert(text.trim());
     // }
-    // if (text.trim().length === 0 && text.includes('\n')) {
-    //     return new Delta().insert(text);
-    // }
+    // Interpret a text node than only contains a newline as a soft line break
+    if (text.trim().length === 0 && text.includes('\n')) {
+        return new Delta().insert(LINE_SEPARATOR);
+    }
     if (!isPre(node)) {
         const replacer = (collapse, match) => {
             const replaced = match.replace(/[^\u00a0]/g, ''); // \u00a0 is nbsp;

--- a/frontend/src/app/util/quill/text-soft-break-blot.ts
+++ b/frontend/src/app/util/quill/text-soft-break-blot.ts
@@ -96,7 +96,7 @@ export function textNodeMatcher(node: any, delta: any) {
     //     text = toDeltaText(text);
     //     return new Delta().insert(text.trim());
     // }
-    // Interpret a text node than only contains a newline as a soft line break
+    // Interpret a text node that only contains a newline as a soft line break
     if (text.trim().length === 0 && text.includes('\n')) {
         return new Delta().insert(LINE_SEPARATOR);
     }


### PR DESCRIPTION
This is _slightly_ risky, as it's a behavior change. It seems to result in vastly better pastes from at least _my_ Word docs, though. (no more double blank paragraphs) 

Pastes from GDocs, Fimfic and elsewhere on Offprint seems to result in either the same behavior, or improved behavior re: newlines.