### PR TITLE
Make invalid passwords not crash

### DIFF
--- a/apps/api/src/app/controllers/auth/auth.controller.ts
+++ b/apps/api/src/app/controllers/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, ForbiddenException, Get, Post, Request, UseGuards } from '@nestjs/common';
+import { Body, Controller, ForbiddenException, Get, NotFoundException, Post, Request, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Cookies, SetCookies } from '@nestjsplus/cookies';
 import { RefreshGuard, RolesGuard } from '../../guards';
@@ -34,6 +34,9 @@ export class AuthController {
         const oldSessionId: string | null = cookies['refreshToken'];
 
         const verifiedUser = await this.auth.validateAccount(login.email, login.password);
+        if (!verifiedUser) {
+            throw new NotFoundException(`No user with those credentials found. Have you signed up?`);
+        }
 
         if (oldSessionId) {
             await this.auth.clearRefreshToken(verifiedUser._id, oldSessionId);


### PR DESCRIPTION
## Description
We had a condition where, if a user passed in an invalid password, we'd return a null user (which the caller didn't check for) which meant we kept right on trucking along until exploding on the null. Now, we correctly throw an immediate 404.

(I also changed the logic to be a little easier to follow. Sentinel Pattern ftw)


## Areas Affected
- [x] Sign In/Out

