### PR TITLE
Implements ability to search for multiple genres

### DIFF
--- a/apps/api/src/app/controllers/search/search.controller.ts
+++ b/apps/api/src/app/controllers/search/search.controller.ts
@@ -34,16 +34,21 @@ export class SearchController {
         @Query('kind') kind: SearchKind,
         @Query('author') author: string | null,
         @Query('category') category: WorkKind | null,
-        @Query('genre') genre: Genres | null,
+        @Query('genres') genres: string,
+        @Query('genreSearchAny') genreSearchAny: string,
         @Query('pageNum') pageNum: number,
         @Query('filter') filter: ContentFilter,
     ): Promise<PaginateResult<ContentModel>> {
+        const genresList = genres.split(',') as Genres[];
+        const genreSearchAnyBool = genreSearchAny === 'true';
+
         return await this.searchService.findRelatedContent(
             query,
             kind,
             author,
             category,
-            genre,
+            genresList,
+            genreSearchAnyBool,
             pageNum,
             filter
         );

--- a/apps/api/src/app/services/search/search.service.ts
+++ b/apps/api/src/app/services/search/search.service.ts
@@ -60,7 +60,8 @@ export class SearchService implements ISearch {
         searchKind: SearchKind,
         author: string | null,
         category: WorkKind | null,
-        genre: Genres | null,
+        genres: Genres[] | null,
+        genreSearchAny: boolean,
         pageNum: number,
         contentFilter: ContentFilter
     ): Promise<PaginateResult<ContentModel>> {
@@ -94,11 +95,16 @@ export class SearchService implements ISearch {
                 authorId = users.docs[0]._id;
             }
         }
-        if (Object.values(WorkKind).indexOf(category) < 0) {
+        // Category and genre values are the keys, not the values
+        if (Object.values(WorkKind).indexOf(WorkKind[category]) < 0) {
             category = null;
         }
-        if (Object.values(Genres).indexOf(genre) < 0) {
-            genre = null;
+        
+        const genreList: Genres[] = [];
+        for (let genre of genres) {
+            if (Object.values(Genres).indexOf(Genres[genre]) >= 0) {
+                genreList.push(genre as Genres);
+            }
         }
 
         return await this.contentGroupStore.findRelatedContent(
@@ -106,7 +112,8 @@ export class SearchService implements ISearch {
             kinds,
             authorId,
             category,
-            genre,
+            genreList.length > 0 ? genreList : null,
+            genreSearchAny,
             pageNum,
             this.MAX_PER_PAGE,
             contentFilter
@@ -133,6 +140,7 @@ export class SearchService implements ISearch {
             null,
             null,
             null,
+            true,
             pageNum,
             this.MAX_PER_PAGE,
             contentFilter
@@ -154,6 +162,7 @@ export class SearchService implements ISearch {
             null,
             null,
             null,
+            true,
             pageNum,
             this.MAX_PER_PAGE,
             contentFilter

--- a/apps/api/src/app/shared/search/search.interface.ts
+++ b/apps/api/src/app/shared/search/search.interface.ts
@@ -21,6 +21,8 @@ export interface ISearch {
      * @param searchKind The kind of content that searching for
      * @param author (Optional) The author of content that searching for
      * @param category (Optional) The category of content that searching for
+     * @param genres (Optional) The genres of content that searching for.
+     * @param genreSearchAny When searching genre, whether all genres should match or just one or more.
      * @param pageNum The current results page
      * @param contentFilter Any available content filter
      */
@@ -29,7 +31,8 @@ export interface ISearch {
         searchKind: SearchKind,
         author: string | null,
         category: WorkKind | null,
-        genre: Genres | null,
+        genres: Genres[] | null,
+        genreSearchAny: boolean,
         pageNum: number,
         contentFilter: ContentFilter
     ): Promise<PaginateResult<ContentModel>>;

--- a/apps/bettafish/src/app/pages/browse/search/search.component.html
+++ b/apps/bettafish/src/app/pages/browse/search/search.component.html
@@ -35,18 +35,27 @@
                             <div>Category</div>
                             <div class="offprint-select">
                                 <ng-select class="custom" [formControlName]="'category'" [searchable]="false" [placeholder]="'Select Category'">
-                                    <ng-option *ngFor="let category of categoryOptions | keyvalue" [value]="category.key ">
+                                    <ng-option *ngFor="let category of categoryOptions | keyvalue" [value]="category.key">
                                         {{ category.value }}
                                     </ng-option>
                                 </ng-select>
                             </div>
-                            <div>Genre</div>
+                            <div>Genre(s)</div>
                             <div class="offprint-select">
-                                <ng-select class="custom" [formControlName]="'genre'" [searchable]="false" [placeholder]="'Select Genre'">
-                                    <ng-option *ngFor="let genre of genreOptions | keyvalue" [value]="genre.key ">
+                                <ng-select class="custom" [formControlName]="'genres'" [searchable]="false" [multiple]="true" [placeholder]="'Select Genre(s)'">
+                                    <ng-option *ngFor="let genre of genreOptions | keyvalue" [value]="genre.key">
                                         {{ genre.value }}
                                     </ng-option>
                                 </ng-select>
+                            </div>
+                            <div>
+                               <input id="allGenre" type="radio" [value]="false" [formControlName]="'genreSearchAny'">
+                               <label for="allGenre">&nbsp;Match all</label>
+                            </div>
+                         
+                            <div>
+                               <input id="anyGenre" type="radio" [value]="true" [formControlName]="'genreSearchAny'">
+                               <label for="anyGenre">&nbsp;Match one or more</label>
                             </div>
                         </ng-container>
                     </div>

--- a/libs/api/database/src/lib/content/stores/content-group.store.ts
+++ b/libs/api/database/src/lib/content/stores/content-group.store.ts
@@ -216,6 +216,8 @@ export class ContentGroupStore {
      * @param kinds The kind of document to fetch.
      * @param authorId (Optional) ID of author of work that searching for.
      * @param category (Optional) The category of content that searching for.
+     * @param genres (Optional) The genres of content that searching for.
+     * @param genreSearchAny When searching genre, whether all genres should match or just one or more.
      * @param pageNum The page of results to retrieve.
      * @param maxPerPage The maximum number of results per page.
      * @param filter The content filter to apply to returned results.
@@ -225,7 +227,8 @@ export class ContentGroupStore {
         kinds: ContentKind[],
         authorId: string | null,
         category: WorkKind | null,
-        genre: Genres | null,
+        genres: Genres[] | null,
+        genreSearchAny: boolean,
         pageNum: number,
         maxPerPage: number,
         filter: ContentFilter,
@@ -252,8 +255,13 @@ export class ContentGroupStore {
         if (category) {
             paginateQuery['meta.category'] = category;
         }
-        if (genre) {
-            paginateQuery['meta.genres'] = genre;
+        if (genres && genres.length > 0) {
+            if (genreSearchAny) {
+                paginateQuery['meta.genres'] = { $in: genres };
+            }
+            else {
+                paginateQuery['meta.genres'] = { $all: genres };
+            }
         }
         await ContentGroupStore.determineContentFilter(paginateQuery, filter);
         return await this.content.paginate(paginateQuery, paginateOptions);

--- a/libs/client/services/src/lib/dragonfish-network.service.ts
+++ b/libs/client/services/src/lib/dragonfish-network.service.ts
@@ -296,6 +296,8 @@ export class DragonfishNetworkService {
      * @param kind The kind of content that searching for
      * @param author (Optional) The author of content that searching for
      * @param category (Optional) The category of content that searching for
+     * @param genres (Optional) The genres of content that searching for.
+     * @param genreSearchAny When searching genre, whether all genres should match or just one or more.
      * @param pageNum The current results page
      * @param contentFilter The mature/explicit/etc. content filter to apply
      */
@@ -304,14 +306,16 @@ export class DragonfishNetworkService {
         kind: SearchKind,
         author: string | null,
         category: WorkKind | null,
-        genre: Genres | null,
+        genres: Genres[] | null,
+        genreSearchAny: boolean,
         pageNum: number,
         contentFilter: ContentFilter,
     ): Observable<PaginateResult<ContentModel>> {
         return handleResponse(
             this.http.get<PaginateResult<ContentModel>>(
                 `${this.baseUrl}/search/find-related-content?` +
-                    `query=${query}&kind=${kind}&author=${author}&category=${category}&genre=${genre}` +
+                    `query=${query}&kind=${kind}&author=${author}&category=${category}` +
+                    `&genres=${genres}&genreSearchAny=${genreSearchAny}` +
                     `&pageNum=${pageNum}&filter=${contentFilter}`,
                 { observe: 'response', withCredentials: true },
             ),


### PR DESCRIPTION
Addresses ticket #637

## Description
Expands search capabilities and fixes issue when searching for genres with spaces.

## Changes
- Implements ability to search for multiple genres
- Can search for all specified genres, or one or more of them
- Fixes searching for genres with spaces
- Modifies category search code to match
- Searches if URL specifies empty query, doesn't search if parameter not there
- Clears old parameters from URL when search by removing "merge"

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Stuff (main page)
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Collections
- [ ] Comments
- [x] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
