### PR TITLE
Increases max title length to 120 and applies this to blogs

### DIFF
--- a/libs/client/profile/src/lib/views/blog-page/blog-page.component.ts
+++ b/libs/client/profile/src/lib/views/blog-page/blog-page.component.ts
@@ -10,6 +10,7 @@ import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { AlertsService } from '@dragonfish/client/alerts';
 import { AuthService } from '@dragonfish/client/repository/session/services';
 import { ActivatedRoute } from '@angular/router';
+import { MAX_TITLE_LENGTH, MIN_TEXT_LENGTH } from '@dragonfish/shared/constants/content-constants';
 
 @UntilDestroy()
 @Component({
@@ -25,8 +26,12 @@ export class BlogPageComponent implements OnInit {
     pubStatus = PubStatus;
 
     blogForm = new FormGroup({
-        title: new FormControl('', [Validators.required, Validators.minLength(3), Validators.maxLength(64)]),
-        body: new FormControl('', [Validators.required, Validators.minLength(3)]),
+        title: new FormControl('', [
+            Validators.required,
+            Validators.minLength(MIN_TEXT_LENGTH),
+            Validators.maxLength(MAX_TITLE_LENGTH)
+        ]),
+        body: new FormControl('', [Validators.required, Validators.minLength(MIN_TEXT_LENGTH)]),
     });
 
     constructor(
@@ -59,8 +64,12 @@ export class BlogPageComponent implements OnInit {
     }
 
     submitForm(blog: BlogsContentModel) {
-        if (this.blogForm.invalid) {
-            this.alerts.error(`Check the info you entered and try again.`);
+        if (this.blogForm.controls.title.invalid) {
+            this.alerts.warn('Title field has an invalid length. Maximum is '+ MAX_TITLE_LENGTH + ' characters.');
+            return;
+        }
+        if (this.blogForm.controls.body.invalid) {
+            this.alerts.warn('Body text is too short.');
             return;
         }
 

--- a/libs/client/profile/src/lib/views/blogs/blogs.component.ts
+++ b/libs/client/profile/src/lib/views/blogs/blogs.component.ts
@@ -12,6 +12,7 @@ import { AlertsService } from '@dragonfish/client/alerts';
 import { take } from 'rxjs/operators';
 import { AuthService } from '@dragonfish/client/repository/session/services';
 import { ProfileQuery } from '@dragonfish/client/repository/profile';
+import { MIN_TEXT_LENGTH, MAX_TITLE_LENGTH } from '@dragonfish/shared/constants/content-constants';
 
 @Component({
     selector: 'dragonfish-profile-blogs',
@@ -26,8 +27,12 @@ export class BlogsComponent implements OnInit {
     pubStatus = PubStatus;
 
     blogForm = new FormGroup({
-        title: new FormControl('', [Validators.required, Validators.minLength(3), Validators.maxLength(64)]),
-        body: new FormControl('', [Validators.required, Validators.minLength(3)]),
+        title: new FormControl('', [
+            Validators.required,
+            Validators.minLength(MIN_TEXT_LENGTH),
+            Validators.maxLength(MAX_TITLE_LENGTH)
+        ]),
+        body: new FormControl('', [Validators.required, Validators.minLength(MIN_TEXT_LENGTH)]),
     });
 
     constructor(
@@ -63,8 +68,12 @@ export class BlogsComponent implements OnInit {
     }
 
     submitForm(asDraft: boolean) {
-        if (this.blogForm.invalid) {
-            this.alerts.error(`Check the info you entered and try again.`);
+        if (this.blogForm.controls.title.invalid) {
+            this.alerts.warn('Title field has an invalid length. Maximum is '+ MAX_TITLE_LENGTH + ' characters.');
+            return;
+        }
+        if (this.blogForm.controls.body.invalid) {
+            this.alerts.warn('Body text is too short.');
             return;
         }
 

--- a/libs/client/ui/src/lib/components/work-form/work-form.component.ts
+++ b/libs/client/ui/src/lib/components/work-form/work-form.component.ts
@@ -109,7 +109,7 @@ export class WorkFormComponent implements OnInit {
 
     submitForm() {
         if (this.fields.title.invalid) {
-            this.alerts.warn('Title field has an invalid length.');
+            this.alerts.warn('Title field has an invalid length. Maximum is '+ MAX_TITLE_LENGTH + ' characters.');
             return;
         }
         if (this.fields.desc.invalid) {

--- a/libs/shared/src/lib/constants/content-constants.ts
+++ b/libs/shared/src/lib/constants/content-constants.ts
@@ -1,5 +1,5 @@
 export const MIN_TEXT_LENGTH = 3;
-export const MAX_TITLE_LENGTH = 100;
+export const MAX_TITLE_LENGTH = 120;
 export const MAX_DESC_LENGTH = 250;
 
 export const MIN_GENRES = 1;


### PR DESCRIPTION
## Description
Users have run into issues with the blog title length being 64, which is too low.

## Changes
Increases max title length to 120 and applies this to blogs

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Stuff (main page)
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [x] Work Page
- [x] Blog Page
- [ ] Collections
- [ ] Comments
- [ ] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
