### PR TITLE
Converts mobile navbar to floating menu, part 1

### DIFF
--- a/apps/client/src/app.scss
+++ b/apps/client/src/app.scss
@@ -41,7 +41,7 @@
 
 html,
 body {
-    @apply relative w-full h-full overflow-x-hidden overflow-y-hidden;
+    @apply relative min-w-full min-h-full overflow-x-hidden overflow-y-hidden;
 }
 body {
     color: var(--text-color);

--- a/apps/client/src/app.scss
+++ b/apps/client/src/app.scss
@@ -41,7 +41,7 @@
 
 html,
 body {
-    @apply relative min-w-full min-h-full overflow-x-hidden overflow-y-hidden;
+    @apply relative min-w-full min-h-full overflow-x-hidden;
 }
 body {
     color: var(--text-color);

--- a/apps/client/src/lib/components/nav/MobileBanner.svelte
+++ b/apps/client/src/lib/components/nav/MobileBanner.svelte
@@ -1,0 +1,17 @@
+<div class="banner md:hidden">
+    <a href="/" class="flex-1">
+        <img
+            src="/images/logo.png"
+            alt="logo"
+            style="max-width: 16rem; margin: 0 auto;"
+            class="relative z-30"
+        />
+    </a>
+</div>
+
+<style lang="scss">
+    div.banner {
+        @apply text-white text-center py-2 w-full flex flex-col items-center justify-center;
+        background: var(--accent);
+    }
+</style>

--- a/apps/client/src/lib/components/nav/MobileMenu.svelte
+++ b/apps/client/src/lib/components/nav/MobileMenu.svelte
@@ -31,7 +31,7 @@
     }
 </script>
 
-<div class="flex flex-col w-full h-[calc(100vh-51px)] md:h-screen overflow-y-auto">
+<div class="flex flex-col w-full h-screen overflow-y-auto">
     <div class="menu-header">
         {#if $session.currProfile}
             <a href={`/profile/${$session.currProfile._id}`} class="login-link">

--- a/apps/client/src/lib/components/nav/MobileNav.svelte
+++ b/apps/client/src/lib/components/nav/MobileNav.svelte
@@ -119,12 +119,13 @@
 
 <style lang="scss">
     div.navbar {
-        @apply w-full z-50 fixed;
+        @apply w-full z-50 px-1 fixed;
     }
 
     a.link-mobile,
     div.link-mobile {
         @apply block p-2 z-50 rounded-lg text-white transition transform flex flex-col items-center justify-center w-[50px] h-[50px];
+        background: var(--accent-transparent);
     }
     div.menu {
         @apply h-screen z-40 relative min-w-[24rem] max-w-[24rem];

--- a/apps/client/src/lib/components/nav/MobileNav.svelte
+++ b/apps/client/src/lib/components/nav/MobileNav.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+    import { navigating } from '$app/stores';
+    import {
+        CloseLine,
+        SearchEyeLine,
+        MenuLine,
+    } from 'svelte-remixicon';
+    import { open, close, sidenav } from '$lib/components/nav/sidenav/sidenav.state';
+    import UserMenu from '$lib/components/ui/user/UserMenu.svelte';
+    import { session } from '$lib/repo/session.repo';
+    import InboxMenu from '$lib/components/ui/user/InboxMenu.svelte';
+    import ContentMenu from '../ui/user/ContentMenu.svelte';
+    import { useQuery } from '@sveltestack/svelte-query';
+    import { fetchAllUnread } from '$lib/services/activity.service';
+    import MobileMenu from '$lib/components/nav/MobileMenu.svelte';
+
+    enum MenuOptions {
+        NoMenu,
+        UserMenu,
+        CreateMenu,
+        MobileMenu,
+        InboxMenu,
+    }
+
+    let currentMenu = MenuOptions.NoMenu;
+    $: {
+        if (!$sidenav.isOpen) {
+            currentMenu = MenuOptions.NoMenu;
+        }
+    }
+
+    function toggleMenu(menuOption: MenuOptions) {
+        currentMenu = menuOption;
+        switch (currentMenu) {
+            case MenuOptions.UserMenu:
+                open(UserMenu);
+                break;
+            case MenuOptions.CreateMenu:
+                open(ContentMenu);
+                break;
+            case MenuOptions.InboxMenu:
+                open(InboxMenu);
+                break;
+            case MenuOptions.MobileMenu:
+                open(MobileMenu);
+                break;
+            default:
+                close();
+                break;
+        }
+    }
+
+    navigating.subscribe((val) => {
+        if (val !== null) {
+            currentMenu = MenuOptions.NoMenu;
+            close();
+        }
+    });
+
+    const activity = useQuery('unreadActivity', () => fetchAllUnread($session.currProfile._id), {
+        enabled: !!$session.currProfile,
+        cacheTime: 1000 * 60 * 0.25,
+    });
+</script>
+
+<div class="navbar">
+    <div class="p-1 flex items-center block md:hidden">
+        {#if currentMenu === MenuOptions.MobileMenu}
+            <div
+                class="link-mobile select-none cursor-pointer group"
+                class:active={currentMenu === MenuOptions.MobileMenu}
+                on:click={() => toggleMenu(MenuOptions.NoMenu)}
+            >
+                <span class="link-icon"><CloseLine size="24px" /></span>
+            </div>
+        {:else}
+            <div
+                class="link-mobile select-none cursor-pointer group"
+                class:active={currentMenu === MenuOptions.MobileMenu}
+                on:click={() => toggleMenu(MenuOptions.MobileMenu)}
+            >
+                <span class="link-icon"><MenuLine size="24px" /></span>
+            </div>
+        {/if}
+        <a href="/" class="flex-1">
+            <img
+                src="/images/logo.png"
+                alt="logo"
+                style="max-width: 8rem; margin: 0 auto;"
+                class="relative z-30"
+            />
+        </a>
+        <a href="/search" class="link-mobile select-none cursor-pointer group">
+            <span class="link-icon"><SearchEyeLine size="24px" /></span>
+        </a>
+    </div>
+</div>
+
+<style lang="scss">
+    div.navbar {
+        @apply w-full md:h-screen md:w-[75px] z-50 relative;
+        background: var(--accent);
+        box-shadow: var(--dropshadow);
+    }
+
+    a.link-mobile,
+    div.link-mobile {
+        @apply block p-2 rounded-lg text-white transition transform flex flex-col items-center justify-center w-[50px] h-[50px] relative;
+    }
+</style>

--- a/apps/client/src/lib/components/nav/MobileNav.svelte
+++ b/apps/client/src/lib/components/nav/MobileNav.svelte
@@ -13,6 +13,7 @@
     import { useQuery } from '@sveltestack/svelte-query';
     import { fetchAllUnread } from '$lib/services/activity.service';
     import MobileMenu from '$lib/components/nav/MobileMenu.svelte';
+    import { fly, fade } from 'svelte/transition';
 
     enum MenuOptions {
         NoMenu,
@@ -99,6 +100,22 @@
         </a>
     </div>
 </div>
+<div class="flex-1 relative">
+    {#if $sidenav.isOpen}
+        <div class="absolute z-40 top-0 h-screen w-full flex">
+            <div
+                class="absolute z-30 bg-neutral-900 w-full h-screen opacity-75 backdrop-blur-md"
+                transition:fade|local={{ delay: 0, duration: 100 }}
+                on:click={close}
+            />
+            <div class="menu" transition:fly|local={{ delay: 0, duration: 200, x: -200 }}>
+                <svelte:component this={$sidenav.component} />
+            </div>
+        </div>
+    {/if}
+
+    <slot />
+</div>
 
 <style lang="scss">
     div.navbar {
@@ -108,5 +125,9 @@
     a.link-mobile,
     div.link-mobile {
         @apply block p-2 z-50 rounded-lg text-white transition transform flex flex-col items-center justify-center w-[50px] h-[50px];
+    }
+    div.menu {
+        @apply h-screen z-40 relative min-w-full max-w-full md:min-w-[24rem] md:max-w-[24rem];
+        background: var(--background);
     }
 </style>

--- a/apps/client/src/lib/components/nav/MobileNav.svelte
+++ b/apps/client/src/lib/components/nav/MobileNav.svelte
@@ -14,6 +14,7 @@
     import { fetchAllUnread } from '$lib/services/activity.service';
     import MobileMenu from '$lib/components/nav/MobileMenu.svelte';
     import { fly, fade } from 'svelte/transition';
+    import MobileBanner from './MobileBanner.svelte';
 
     enum MenuOptions {
         NoMenu,
@@ -99,6 +100,7 @@
         </div>
     {/if}
 
+    <MobileBanner />
     <slot />
 </div>
 

--- a/apps/client/src/lib/components/nav/MobileNav.svelte
+++ b/apps/client/src/lib/components/nav/MobileNav.svelte
@@ -127,7 +127,7 @@
         @apply block p-2 z-50 rounded-lg text-white transition transform flex flex-col items-center justify-center w-[50px] h-[50px];
     }
     div.menu {
-        @apply h-screen z-40 relative min-w-full max-w-full md:min-w-[24rem] md:max-w-[24rem];
+        @apply h-screen z-40 relative min-w-[24rem] max-w-[24rem];
         background: var(--background);
     }
 </style>

--- a/apps/client/src/lib/components/nav/MobileNav.svelte
+++ b/apps/client/src/lib/components/nav/MobileNav.svelte
@@ -100,11 +100,11 @@
         </a>
     </div>
 </div>
-<div class="flex-1 relative">
+<div class="relative">
     {#if $sidenav.isOpen}
-        <div class="absolute z-40 top-0 h-screen w-full flex">
+        <div class="fixed z-40 top-0 h-screen w-full flex">
             <div
-                class="absolute z-30 bg-neutral-900 w-full h-screen opacity-75 backdrop-blur-md"
+                class="fixed z-30 bg-neutral-900 w-full h-screen opacity-75 backdrop-blur-md"
                 transition:fade|local={{ delay: 0, duration: 100 }}
                 on:click={close}
             />
@@ -119,7 +119,7 @@
 
 <style lang="scss">
     div.navbar {
-        @apply w-full absolute;
+        @apply w-full z-50 fixed;
     }
 
     a.link-mobile,

--- a/apps/client/src/lib/components/nav/MobileNav.svelte
+++ b/apps/client/src/lib/components/nav/MobileNav.svelte
@@ -82,14 +82,18 @@
                 <span class="link-icon"><MenuLine size="24px" /></span>
             </div>
         {/if}
-        <a href="/" class="flex-1">
+        <!-- <a href="/" class="flex-1">
             <img
                 src="/images/logo.png"
                 alt="logo"
                 style="max-width: 8rem; margin: 0 auto;"
                 class="relative z-30"
             />
-        </a>
+        </a> -->
+        <div
+            style="max-width: 8rem; margin: 0 auto;"
+            class="relative z-30"
+        />
         <a href="/search" class="link-mobile select-none cursor-pointer group">
             <span class="link-icon"><SearchEyeLine size="24px" /></span>
         </a>
@@ -98,13 +102,11 @@
 
 <style lang="scss">
     div.navbar {
-        @apply w-full md:h-screen md:w-[75px] z-50 relative;
-        background: var(--accent);
-        box-shadow: var(--dropshadow);
+        @apply w-full absolute;
     }
 
     a.link-mobile,
     div.link-mobile {
-        @apply block p-2 rounded-lg text-white transition transform flex flex-col items-center justify-center w-[50px] h-[50px] relative;
+        @apply block p-2 z-50 rounded-lg text-white transition transform flex flex-col items-center justify-center w-[50px] h-[50px];
     }
 </style>

--- a/apps/client/src/lib/components/nav/MobileNav.svelte
+++ b/apps/client/src/lib/components/nav/MobileNav.svelte
@@ -63,42 +63,27 @@
         cacheTime: 1000 * 60 * 0.25,
     });
 </script>
-
-<div class="navbar">
-    <div class="p-1 flex items-center block md:hidden">
-        {#if currentMenu === MenuOptions.MobileMenu}
-            <div
-                class="link-mobile select-none cursor-pointer group"
-                class:active={currentMenu === MenuOptions.MobileMenu}
-                on:click={() => toggleMenu(MenuOptions.NoMenu)}
-            >
-                <span class="link-icon"><CloseLine size="24px" /></span>
-            </div>
-        {:else}
-            <div
-                class="link-mobile select-none cursor-pointer group"
-                class:active={currentMenu === MenuOptions.MobileMenu}
-                on:click={() => toggleMenu(MenuOptions.MobileMenu)}
-            >
-                <span class="link-icon"><MenuLine size="24px" /></span>
-            </div>
-        {/if}
-        <!-- <a href="/" class="flex-1">
-            <img
-                src="/images/logo.png"
-                alt="logo"
-                style="max-width: 8rem; margin: 0 auto;"
-                class="relative z-30"
-            />
-        </a> -->
+<div class="md:hidden">
+    {#if currentMenu === MenuOptions.MobileMenu}
         <div
-            style="max-width: 8rem; margin: 0 auto;"
-            class="relative z-30"
-        />
-        <a href="/search" class="link-mobile select-none cursor-pointer group">
-            <span class="link-icon"><SearchEyeLine size="24px" /></span>
-        </a>
-    </div>
+            class="link-mobile select-none cursor-pointer group"
+            class:active={currentMenu === MenuOptions.MobileMenu}
+            on:click={() => toggleMenu(MenuOptions.NoMenu)}
+        >
+            <span class="link-icon"><CloseLine size="24px" /></span>
+        </div>
+    {:else}
+        <div
+            class="link-mobile select-none cursor-pointer group"
+            class:active={currentMenu === MenuOptions.MobileMenu}
+            on:click={() => toggleMenu(MenuOptions.MobileMenu)}
+        >
+            <span class="link-icon"><MenuLine size="24px" /></span>
+        </div>
+    {/if}
+    <a href="/search" class="right-0 link-mobile select-none cursor-pointer group">
+        <span class="link-icon"><SearchEyeLine size="24px" /></span>
+    </a>
 </div>
 <div class="relative">
     {#if $sidenav.isOpen}
@@ -118,13 +103,9 @@
 </div>
 
 <style lang="scss">
-    div.navbar {
-        @apply w-full z-50 px-1 fixed;
-    }
-
     a.link-mobile,
     div.link-mobile {
-        @apply block p-2 z-50 rounded-lg text-white transition transform flex flex-col items-center justify-center w-[50px] h-[50px];
+        @apply fixed block m-2 z-50 rounded-lg text-white transition transform flex flex-col items-center justify-center w-[50px] h-[50px];
         background: var(--accent-transparent);
     }
     div.menu {

--- a/apps/client/src/lib/components/nav/Nav.svelte
+++ b/apps/client/src/lib/components/nav/Nav.svelte
@@ -11,7 +11,6 @@
         AddBoxLine,
         Dashboard2Line,
         SearchEyeLine,
-        MenuLine,
         GroupLine,
     } from 'svelte-remixicon';
     import { open, close, sidenav } from '$lib/components/nav/sidenav/sidenav.state';
@@ -215,36 +214,6 @@
             <span class="link-name">Settings</span>
         </a>
     </div>
-    <div class="p-1 flex items-center block md:hidden">
-        {#if currentMenu === MenuOptions.MobileMenu}
-            <div
-                class="link-mobile select-none cursor-pointer group"
-                class:active={currentMenu === MenuOptions.MobileMenu}
-                on:click={() => toggleMenu(MenuOptions.NoMenu)}
-            >
-                <span class="link-icon"><CloseLine size="24px" /></span>
-            </div>
-        {:else}
-            <div
-                class="link-mobile select-none cursor-pointer group"
-                class:active={currentMenu === MenuOptions.MobileMenu}
-                on:click={() => toggleMenu(MenuOptions.MobileMenu)}
-            >
-                <span class="link-icon"><MenuLine size="24px" /></span>
-            </div>
-        {/if}
-        <a href="/" class="flex-1">
-            <img
-                src="/images/logo.png"
-                alt="logo"
-                style="max-width: 8rem; margin: 0 auto;"
-                class="relative z-30"
-            />
-        </a>
-        <a href="/search" class="link-mobile select-none cursor-pointer group">
-            <span class="link-icon"><SearchEyeLine size="24px" /></span>
-        </a>
-    </div>
 </div>
 
 <style lang="scss">
@@ -287,10 +256,5 @@
             width: 57px;
             height: 57px;
         }
-    }
-
-    a.link-mobile,
-    div.link-mobile {
-        @apply block p-2 rounded-lg text-white transition transform flex flex-col items-center justify-center w-[50px] h-[50px] relative;
     }
 </style>

--- a/apps/client/src/routes/__layout.svelte
+++ b/apps/client/src/routes/__layout.svelte
@@ -39,10 +39,9 @@
         class:light={$app.darkMode === false}
         on:dragover|preventDefault
     >
-        <MobileNav />
-        <Sidenav>
+        <MobileNav>
             <slot />
-        </Sidenav>
+        </MobileNav>
     </main>
     <SvelteToast />
 </QueryClientProvider>

--- a/apps/client/src/routes/__layout.svelte
+++ b/apps/client/src/routes/__layout.svelte
@@ -34,7 +34,7 @@
     </main>
     <!-- Mobile -->
     <main
-        class="flex flex-col md:hidden h-screen {$app.theme}"
+        class="flex flex-col md:hidden min-h-screen {$app.theme}"
         class:dark={$app.darkMode === true}
         class:light={$app.darkMode === false}
         on:dragover|preventDefault

--- a/apps/client/src/routes/__layout.svelte
+++ b/apps/client/src/routes/__layout.svelte
@@ -19,8 +19,21 @@
 
 <QueryClientProvider client={queryClient}>
     <Popup />
+    <!-- Desktop -->
     <main
-        class="flex flex-col md:flex-row h-screen {$app.theme}"
+        class="flex-col hidden md:flex md:flex-row h-screen {$app.theme}"
+        class:dark={$app.darkMode === true}
+        class:light={$app.darkMode === false}
+        on:dragover|preventDefault
+    >
+        <Nav />
+        <Sidenav>
+            <slot />
+        </Sidenav>
+    </main>
+    <!-- Mobile -->
+    <main
+        class="flex flex-col md:hidden h-screen {$app.theme}"
         class:dark={$app.darkMode === true}
         class:light={$app.darkMode === false}
         on:dragover|preventDefault

--- a/apps/client/src/routes/__layout.svelte
+++ b/apps/client/src/routes/__layout.svelte
@@ -8,6 +8,7 @@
     import { queryClient } from '$lib/util';
     import { Sidenav } from '$lib/components/nav/sidenav';
     import { Popup } from '$lib/components/nav/popup';
+    import MobileNav from '$lib/components/nav/MobileNav.svelte';
 
     onMount(async () => {
         await broadcastQueryClient({
@@ -38,7 +39,7 @@
         class:light={$app.darkMode === false}
         on:dragover|preventDefault
     >
-        <Nav />
+        <MobileNav />
         <Sidenav>
             <slot />
         </Sidenav>

--- a/apps/client/src/routes/blog/[id].svelte
+++ b/apps/client/src/routes/blog/[id].svelte
@@ -245,7 +245,7 @@
 </svelte:head>
 
 {#if $session && $content && $content.content}
-    <div class="w-full h-screen overflow-y-auto">
+    <div class="w-full min-h-screen md:h-screen overflow-y-auto">
         <div class="mx-auto max-w-4xl my-6">
             {#if $content.content.meta.banner}
                 <div class="mx-auto w-11/12 md:w-full rounded-t-lg overflow-hidden">

--- a/apps/client/src/routes/create/new-blog.svelte
+++ b/apps/client/src/routes/create/new-blog.svelte
@@ -51,7 +51,7 @@
     <title>Create Blog &mdash; Offprint</title>
 </svelte:head>
 
-<div class="w-full h-screen overflow-y-auto">
+<div class="w-full min-h-screen md:h-screen overflow-y-auto">
     <div class="max-w-4xl w-11/12 md:w-7/12 mx-auto my-10 mb-6">
         <h1 class="text-center text-4xl font-medium">Create New Blog</h1>
         <form use:form>

--- a/apps/client/src/routes/create/new-poetry.svelte
+++ b/apps/client/src/routes/create/new-poetry.svelte
@@ -170,7 +170,7 @@
     <title>Create Poetry &mdash; Offprint</title>
 </svelte:head>
 
-<div class="w-full h-screen overflow-y-auto">
+<div class="w-full min-h-screen md:h-screen overflow-y-auto">
     <div class="max-w-4xl w-11/12 md:w-7/12 mx-auto my-10 mb-6">
         <h1 class="text-center text-4xl font-medium">Create New Poetry</h1>
         <form use:form>

--- a/apps/client/src/routes/create/new-prose.svelte
+++ b/apps/client/src/routes/create/new-prose.svelte
@@ -157,7 +157,7 @@
     <title>Create Prose &mdash; Offprint</title>
 </svelte:head>
 
-<div class="w-full h-screen overflow-y-auto">
+<div class="w-full min-h-screen md:h-screen overflow-y-auto">
     <div class="max-w-4xl w-11/12 md:w-7/12 mx-auto my-10 mb-6">
         <h1 class="text-center text-4xl font-medium">Create New Prose</h1>
         <form use:form>

--- a/apps/client/src/routes/dashboard/__layout.svelte
+++ b/apps/client/src/routes/dashboard/__layout.svelte
@@ -42,7 +42,7 @@
     import PageNav from '$lib/components/nav/PageNav.svelte';
 </script>
 
-<div class="flex w-full h-screen">
+<div class="flex w-full min-h-screen md:h-screen">
     <PageNav>
         <svelte:fragment slot="header">
             <h3>Dashboard</h3>
@@ -102,7 +102,7 @@
             {/if}
         </svelte:fragment>
     </PageNav>
-    <div class="w-full h-screen overflow-y-auto">
+    <div class="w-full min-h-screen md:h-screen overflow-y-auto">
         <slot />
     </div>
 </div>

--- a/apps/client/src/routes/dashboard/tags/index.svelte
+++ b/apps/client/src/routes/dashboard/tags/index.svelte
@@ -65,7 +65,7 @@
     <title>Tags Management &mdash; Offprint</title>
 </svelte:head>
 
-<div class="w-full h-[calc(100vh-51px)] md:h-screen overflow-y-auto flex flex-col mx-auto p-2">
+<div class="w-full h-screen overflow-y-auto flex flex-col mx-auto p-2">
     <div class="flex flex-wrap items-center justify-center text-2xl">
         {#each alphabeticalTags as section, index}
             {#if index !== 0}

--- a/apps/client/src/routes/dashboard/tags/index.svelte
+++ b/apps/client/src/routes/dashboard/tags/index.svelte
@@ -65,7 +65,7 @@
     <title>Tags Management &mdash; Offprint</title>
 </svelte:head>
 
-<div class="w-full h-screen overflow-y-auto flex flex-col mx-auto p-2">
+<div class="w-full min-h-screen md:h-screen overflow-y-auto flex flex-col mx-auto p-2">
     <div class="flex flex-wrap items-center justify-center text-2xl">
         {#each alphabeticalTags as section, index}
             {#if index !== 0}

--- a/apps/client/src/routes/explore/__layout.svelte
+++ b/apps/client/src/routes/explore/__layout.svelte
@@ -89,7 +89,7 @@
     });
 </script>
 
-<div class="flex flex-col md:flex-row w-full h-[calc(100vh-51px)] md:h-screen overflow-y-auto md:overflow-y-visible">
+<div class="flex flex-col md:flex-row w-full h-screen overflow-y-auto md:overflow-y-visible">
     <PageNav>
         <svelte:fragment slot="header">
             <h3>Explore</h3>

--- a/apps/client/src/routes/explore/__layout.svelte
+++ b/apps/client/src/routes/explore/__layout.svelte
@@ -89,7 +89,7 @@
     });
 </script>
 
-<div class="flex flex-col md:flex-row w-full h-screen overflow-y-auto md:overflow-y-visible">
+<div class="flex flex-col md:flex-row w-full min-h-screen md:h-screen overflow-y-auto md:overflow-y-visible">
     <PageNav>
         <svelte:fragment slot="header">
             <h3>Explore</h3>

--- a/apps/client/src/routes/explore/following/__layout.svelte
+++ b/apps/client/src/routes/explore/following/__layout.svelte
@@ -37,7 +37,7 @@
     });
 </script>
 
-<div class="w-full h-screen overflow-y-auto flex flex-col">
+<div class="w-full min-h-screen md:h-screen overflow-y-auto flex flex-col">
     <div class="w-full">
         {#if $followsList.isLoading}
             <div class="h-32 flex flex-col items-center justify-center">

--- a/apps/client/src/routes/explore/index.svelte
+++ b/apps/client/src/routes/explore/index.svelte
@@ -43,7 +43,7 @@
     <title>New Works &mdash; Offprint</title>
 </svelte:head>
 
-<div class="w-full h-[calc(100vh-51px)] md:h-screen md:overflow-y-auto">
+<div class="w-full h-screen md:overflow-y-auto">
     {#if !$session || !$session.account }
         <NotifyBanner
             message={ALPHA_MESSAGE}

--- a/apps/client/src/routes/explore/index.svelte
+++ b/apps/client/src/routes/explore/index.svelte
@@ -43,7 +43,7 @@
     <title>New Works &mdash; Offprint</title>
 </svelte:head>
 
-<div class="w-full h-screen md:overflow-y-auto">
+<div class="w-full min-h-screen md:h-screen md:overflow-y-auto">
     {#if !$session || !$session.account }
         <NotifyBanner
             message={ALPHA_MESSAGE}

--- a/apps/client/src/routes/explore/library/index.svelte
+++ b/apps/client/src/routes/explore/library/index.svelte
@@ -12,7 +12,7 @@
 
 {#if $session.currProfile}
     {#if $library.isLoading}
-        <div class="h-screen flex-1 flex flex-col items-center justify-center">
+        <div class="min-h-screen md:h-screen flex-1 flex flex-col items-center justify-center">
             <div class="flex items-center">
                 <Loader5Line class="mr-2" size="24px" />
                 <span class="uppercase font-bold tracking-widest">Loading...</span>
@@ -27,7 +27,7 @@
             </p>
         </div>
     {:else if $library.data.length > 0}
-        <div class="w-full overflow-y-auto">
+        <div class="min-h-screen md:h-screen w-full overflow-y-auto">
             <div class="w-11/12 mx-auto my-6 max-w-7xl">
                 <div
                     class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-3 mb-6"

--- a/apps/client/src/routes/explore/library/shelf/[id].svelte
+++ b/apps/client/src/routes/explore/library/shelf/[id].svelte
@@ -47,14 +47,14 @@
 </script>
 
 {#if $thisShelf.isLoading}
-    <div class="h-screen flex flex-col items-center justify-center">
+    <div class="min-h-screen md:h-screen flex flex-col items-center justify-center">
         <div class="flex items-center">
             <Loader5Line class="mr-2 animate-spin" size="24px" />
             <span class="text-lg uppercase font-bold tracking-widest">Loading...</span>
         </div>
     </div>
 {:else if $thisShelf.isError}
-    <div class="h-screen flex flex-col items-center justify-center">
+    <div class="min-h-screen md:h-screen flex flex-col items-center justify-center">
         <div class="flex items-center">
             <CloseLine class="mr-2" size="24px" />
             <span class="text-lg uppercase font-bold tracking-widest">
@@ -63,7 +63,7 @@
         </div>
     </div>
 {:else}
-    <div class="flex-1 h-screen overflow-y-auto">
+    <div class="flex-1 min-h-screen md:h-screen overflow-y-auto">
         <div class="w-11/12 mx-auto md:max-w-4xl my-6">
             <BookshelfHeader shelf={$thisShelf.data} showTools={true} />
             {#if $shelfItems.isLoading}

--- a/apps/client/src/routes/explore/tags.svelte
+++ b/apps/client/src/routes/explore/tags.svelte
@@ -59,7 +59,7 @@
     <title>Tags &mdash; Offprint</title>
 </svelte:head>
 
-<div class="w-full h-[calc(100vh-51px)] md:h-screen md:overflow-y-auto flex flex-col mx-auto p-2">
+<div class="w-full h-screen md:overflow-y-auto flex flex-col mx-auto p-2">
     <div class="flex flex-wrap items-center justify-center text-2xl">
         {#each alphabeticalTags as section, index}
             {#if index !== 0}

--- a/apps/client/src/routes/explore/tags.svelte
+++ b/apps/client/src/routes/explore/tags.svelte
@@ -18,23 +18,19 @@
             let savedLetter: string;
             let currentAlphaTags: AlphabeticalTags;
             for (const tag of tagTrees) {
-                console.log("Checking " + tag.name);
                 // If tag doesn't have any works, then skip
                 if (!tag.taggedWorks) {
-                    console.log(tag.name + " has no tagged works");
                     continue;
                 }
                 // If first letter doesn't match saved letter, save letter and move to new section
                 // Then either way, add to that letter's array
                 if (savedLetter !== tag.name[0].toUpperCase()) {
-                    console.log("New letter, " + tag.name[0].toUpperCase());
                     if (currentAlphaTags) {
                         alphabeticalTags = [... alphabeticalTags, currentAlphaTags]
                     }
                     savedLetter = tag.name[0].toUpperCase();
                     currentAlphaTags = new AlphabeticalTags(tag.name[0].toUpperCase());
                 }
-                console.log("Adding tag " + tag.name);
                 currentAlphaTags.tags.push(tag);
             }
             // Add last set
@@ -59,7 +55,7 @@
     <title>Tags &mdash; Offprint</title>
 </svelte:head>
 
-<div class="w-full h-screen md:overflow-y-auto flex flex-col mx-auto p-2">
+<div class="w-full min-h-screen md:h-screen md:overflow-y-auto flex flex-col mx-auto p-2">
     <div class="flex flex-wrap items-center justify-center text-2xl">
         {#each alphabeticalTags as section, index}
             {#if index !== 0}

--- a/apps/client/src/routes/index.svelte
+++ b/apps/client/src/routes/index.svelte
@@ -43,7 +43,7 @@
     <meta property="twitter:image" content="/images/offprint_icon.png" />
 </svelte:head>
 
-<div class="w-full md:h-screen overflow-y-auto">
+<div class="w-full h-screen overflow-y-auto">
     <div class="w-full mb-6">
         <div class="home-header hidden md:block">
             <img

--- a/apps/client/src/routes/index.svelte
+++ b/apps/client/src/routes/index.svelte
@@ -43,7 +43,7 @@
     <meta property="twitter:image" content="/images/offprint_icon.png" />
 </svelte:head>
 
-<div class="w-full min-h-screen md:h-screen overflow-y-auto">
+<div class="w-full md:h-screen overflow-y-auto">
     <div class="w-full mb-6">
         <div class="home-header hidden md:block">
             <img

--- a/apps/client/src/routes/index.svelte
+++ b/apps/client/src/routes/index.svelte
@@ -44,7 +44,7 @@
     <meta property="twitter:image" content="/images/offprint_icon.png" />
 </svelte:head>
 
-<div class:h-screen={$sidenav.isOpen} class="w-full min-h-screen md:h-screen overflow-y-auto">
+<div class="w-full min-h-screen md:h-screen overflow-y-auto">
     <div class="w-full mb-6">
         <div class="home-header hidden md:block">
             <img

--- a/apps/client/src/routes/index.svelte
+++ b/apps/client/src/routes/index.svelte
@@ -10,8 +10,6 @@
     import { ALPHA_MESSAGE } from '$lib/util';
     import { session } from '$lib/repo/session.repo';
     import { NotifyBanner } from '$lib/components/ui/misc';
-    import { sidenav } from '$lib/components/nav/sidenav/sidenav.state';
-    import MobileBanner from '$lib/components/nav/MobileBanner.svelte';
 
     const currSlogan = slogans[Math.floor(Math.random() * slogans.length)];
     const newWorks = useQuery('newWorks', () => fetchFirstNew($app.filter));
@@ -56,7 +54,6 @@
             />
             <h2 class="text-white text-2xl relative z-30">{currSlogan}</h2>
         </div>
-        <MobileBanner />
         <div class="jumbo-carousel">
             <Jumbotron />
         </div>

--- a/apps/client/src/routes/index.svelte
+++ b/apps/client/src/routes/index.svelte
@@ -10,6 +10,7 @@
     import { ALPHA_MESSAGE } from '$lib/util';
     import { session } from '$lib/repo/session.repo';
     import { NotifyBanner } from '$lib/components/ui/misc';
+    import { sidenav } from '$lib/components/nav/sidenav/sidenav.state';
 
     const currSlogan = slogans[Math.floor(Math.random() * slogans.length)];
     const newWorks = useQuery('newWorks', () => fetchFirstNew($app.filter));
@@ -43,7 +44,7 @@
     <meta property="twitter:image" content="/images/offprint_icon.png" />
 </svelte:head>
 
-<div class="w-full min-h-screen md:h-screen overflow-y-auto">
+<div class:h-screen={$sidenav.isOpen} class="w-full min-h-screen md:h-screen overflow-y-auto">
     <div class="w-full mb-6">
         <div class="home-header hidden md:block">
             <img

--- a/apps/client/src/routes/index.svelte
+++ b/apps/client/src/routes/index.svelte
@@ -11,6 +11,7 @@
     import { session } from '$lib/repo/session.repo';
     import { NotifyBanner } from '$lib/components/ui/misc';
     import { sidenav } from '$lib/components/nav/sidenav/sidenav.state';
+    import MobileBanner from '$lib/components/nav/MobileBanner.svelte';
 
     const currSlogan = slogans[Math.floor(Math.random() * slogans.length)];
     const newWorks = useQuery('newWorks', () => fetchFirstNew($app.filter));
@@ -55,6 +56,7 @@
             />
             <h2 class="text-white text-2xl relative z-30">{currSlogan}</h2>
         </div>
+        <MobileBanner />
         <div class="jumbo-carousel">
             <Jumbotron />
         </div>

--- a/apps/client/src/routes/index.svelte
+++ b/apps/client/src/routes/index.svelte
@@ -43,7 +43,7 @@
     <meta property="twitter:image" content="/images/offprint_icon.png" />
 </svelte:head>
 
-<div class="w-full h-[calc(100vh-51px)] md:h-screen overflow-y-auto">
+<div class="w-full h-screen overflow-y-auto">
     <div class="w-full mb-6">
         <div class="home-header hidden md:block">
             <img

--- a/apps/client/src/routes/index.svelte
+++ b/apps/client/src/routes/index.svelte
@@ -43,7 +43,7 @@
     <meta property="twitter:image" content="/images/offprint_icon.png" />
 </svelte:head>
 
-<div class="w-full h-screen overflow-y-auto">
+<div class="w-full min-h-screen md:h-screen overflow-y-auto">
     <div class="w-full mb-6">
         <div class="home-header hidden md:block">
             <img

--- a/apps/client/src/routes/poetry/[id]/create-section.svelte
+++ b/apps/client/src/routes/poetry/[id]/create-section.svelte
@@ -117,7 +117,7 @@
     });
 </script>
 
-<div class="w-full h-screen overflow-y-auto">
+<div class="w-full min-h-screen md:h-screen overflow-y-auto">
     <div class="flex flex-col w-full">
         <div class="sticky flex items-center w-full p-2.5 mb-6" style="background: var(--accent)">
             <Button kind="primary" on:click={() => goto(baseUrl)}>

--- a/apps/client/src/routes/poetry/[id]/index.svelte
+++ b/apps/client/src/routes/poetry/[id]/index.svelte
@@ -61,7 +61,7 @@
 </svelte:head>
 
 {#if $content && $content.content}
-    <div class="w-full h-screen overflow-y-auto">
+    <div class="w-full min-h-screen md:h-screen overflow-y-auto">
         <WorkBanner />
         {#if !$session || !$session.account }
             <NotifyBanner

--- a/apps/client/src/routes/poetry/[id]/section/[sectionId].svelte
+++ b/apps/client/src/routes/poetry/[id]/section/[sectionId].svelte
@@ -181,7 +181,7 @@
 </svelte:head>
 
 {#if $session && $content && $content.content && section}
-    <div class="w-full h-screen overflow-y-auto">
+    <div class="w-full min-h-screen md:h-screen overflow-y-auto">
         <div class="flex flex-col w-full">
             <div
                 class="sticky top-0 flex items-center w-full p-2.5 shadow-2xl z-10 h-[56px]"

--- a/apps/client/src/routes/profile/[id]/__layout.svelte
+++ b/apps/client/src/routes/profile/[id]/__layout.svelte
@@ -79,7 +79,7 @@
     );
 </script>
 
-<div class="flex flex-col w-full h-screen overflow-y-auto">
+<div class="flex flex-col w-full min-h-screen md:h-screen overflow-y-auto">
     <div class="profile-header">
         {#if $profile && $profile.profile}
             {#if $profile.profile.coverPic}

--- a/apps/client/src/routes/profile/[id]/shelf/[shelfId].svelte
+++ b/apps/client/src/routes/profile/[id]/shelf/[shelfId].svelte
@@ -33,14 +33,14 @@
 </script>
 
 {#if $thisShelf.isLoading}
-    <div class="h-screen flex flex-col items-center justify-center">
+    <div class="min-h-screen md:h-screen flex flex-col items-center justify-center">
         <div class="flex items-center">
             <Loader5Line class="mr-2 animate-spin" size="24px" />
             <span class="text-lg uppercase font-bold tracking-widest">Loading...</span>
         </div>
     </div>
 {:else if $thisShelf.isError}
-    <div class="h-screen flex flex-col items-center justify-center">
+    <div class="min-h-screen md:h-screen flex flex-col items-center justify-center">
         <div class="flex items-center">
             <CloseLine class="mr-2" size="24px" />
             <span class="text-lg uppercase font-bold tracking-widest">
@@ -49,7 +49,7 @@
         </div>
     </div>
 {:else}
-    <div class="w-11/12 mx-auto md:max-w-4xl mb-6">
+    <div class="min-h-screen md:h-screen w-11/12 mx-auto md:max-w-4xl mb-6">
         <BookshelfHeader shelf={$thisShelf.data} />
         {#if $shelfItems.isLoading}
             <div class="h-96 w-full flex flex-col items-center justify-center">

--- a/apps/client/src/routes/prose/[id]/create-section.svelte
+++ b/apps/client/src/routes/prose/[id]/create-section.svelte
@@ -117,7 +117,7 @@
     });
 </script>
 
-<div class="w-full h-screen overflow-y-auto">
+<div class="w-full min-h-screen md:h-screen overflow-y-auto">
     <div class="flex flex-col w-full">
         <div class="sticky flex items-center w-full p-2.5 mb-6" style="background: var(--accent)">
             <Button kind="primary" on:click={() => goto(baseUrl)}>

--- a/apps/client/src/routes/prose/[id]/index.svelte
+++ b/apps/client/src/routes/prose/[id]/index.svelte
@@ -61,7 +61,7 @@
 </svelte:head>
 
 {#if $content && $content.content}
-    <div class="w-full h-screen overflow-y-auto">
+    <div class="w-full min-h-screen md:h-screen overflow-y-auto">
         <WorkBanner />
         {#if !$session || !$session.account }
             <NotifyBanner

--- a/apps/client/src/routes/prose/[id]/section/[sectionId].svelte
+++ b/apps/client/src/routes/prose/[id]/section/[sectionId].svelte
@@ -184,7 +184,7 @@
     <div class="w-full min-h-screen md:h-screen overflow-y-auto">
         <div class="flex flex-col w-full">
             <div
-                class="top-0 flex items-center w-full p-2.5 shadow-2xl z-10 h-[56px]"
+                class="sticky top-0 flex items-center w-full p-2.5 shadow-2xl z-10 h-[56px]"
                 style="background: var(--accent)"
             >
                 <Button kind="primary" on:click={() => goto(baseUrl)}>

--- a/apps/client/src/routes/prose/[id]/section/[sectionId].svelte
+++ b/apps/client/src/routes/prose/[id]/section/[sectionId].svelte
@@ -181,10 +181,10 @@
 </svelte:head>
 
 {#if $session && $content && $content.content && section}
-    <div class="w-full h-screen overflow-y-auto">
+    <div class="w-full min-h-screen md:h-screen overflow-y-auto">
         <div class="flex flex-col w-full">
             <div
-                class="sticky top-0 flex items-center w-full p-2.5 shadow-2xl z-10 h-[56px]"
+                class="top-0 flex items-center w-full p-2.5 shadow-2xl z-10 h-[56px]"
                 style="background: var(--accent)"
             >
                 <Button kind="primary" on:click={() => goto(baseUrl)}>

--- a/apps/client/src/routes/registration/__layout.svelte
+++ b/apps/client/src/routes/registration/__layout.svelte
@@ -9,7 +9,7 @@
 </svelte:head>
 
 <main
-    class="h-screen w-full flex flex-col items-center justify-center {$app.theme}"
+    class="min-h-screen md:h-screen w-full flex flex-col items-center justify-center {$app.theme}"
     class:dark={$app.darkMode === true}
     class:light={$app.darkMode === false}
 >

--- a/apps/client/src/routes/search/index.svelte
+++ b/apps/client/src/routes/search/index.svelte
@@ -115,7 +115,7 @@
     <title>Search &mdash; Offprint</title>
 </svelte:head>
 
-<div class="w-full h-screen overflow-y-auto">
+<div class="w-full min-h-screen md:h-screen overflow-y-auto">
     <div class="w-11/12 mx-auto max-w-4xl">
         <form
             class="my-10 w-full bg-zinc-300 dark:bg-zinc-700 dark:highlight-shadowed rounded-lg"

--- a/apps/client/src/routes/search/index.svelte
+++ b/apps/client/src/routes/search/index.svelte
@@ -115,7 +115,7 @@
     <title>Search &mdash; Offprint</title>
 </svelte:head>
 
-<div class="w-full h-[calc(100vh-51px)] md:h-screen overflow-y-auto">
+<div class="w-full h-screen overflow-y-auto">
     <div class="w-11/12 mx-auto max-w-4xl">
         <form
             class="my-10 w-full bg-zinc-300 dark:bg-zinc-700 dark:highlight-shadowed rounded-lg"

--- a/apps/client/src/routes/settings/__layout.svelte
+++ b/apps/client/src/routes/settings/__layout.svelte
@@ -17,7 +17,7 @@
 </svelte:head>
 
 <div
-    class="flex flex-col md:flex-row w-full h-[calc(100vh-51px)] md:h-screen overflow-y-auto md:overflow-y-hidden"
+    class="flex flex-col md:flex-row w-full h-screen overflow-y-auto md:overflow-y-hidden"
 >
     <PageNav>
         <svelte:fragment slot="header">

--- a/apps/client/src/routes/settings/__layout.svelte
+++ b/apps/client/src/routes/settings/__layout.svelte
@@ -17,7 +17,7 @@
 </svelte:head>
 
 <div
-    class="flex flex-col md:flex-row w-full h-screen overflow-y-auto md:overflow-y-hidden"
+    class="flex flex-col md:flex-row w-full min-h-screen md:h-screen overflow-y-auto md:overflow-y-hidden"
 >
     <PageNav>
         <svelte:fragment slot="header">

--- a/apps/client/src/routes/social/__layout.svelte
+++ b/apps/client/src/routes/social/__layout.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <div
-    class="flex flex-col md:flex-row w-full h-[calc(100vh-51px)] md:h-screen overflow-y-auto md:overflow-y-hidden"
+    class="flex flex-col md:flex-row w-full h-screen overflow-y-auto md:overflow-y-hidden"
 >
     <PageNav>
         <svelte:fragment slot="header">

--- a/apps/client/src/routes/social/__layout.svelte
+++ b/apps/client/src/routes/social/__layout.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <div
-    class="flex flex-col md:flex-row w-full h-screen overflow-y-auto md:overflow-y-hidden"
+    class="flex flex-col md:flex-row w-full min-h-screen md:h-screen overflow-y-auto md:overflow-y-hidden"
 >
     <PageNav>
         <svelte:fragment slot="header">
@@ -23,7 +23,7 @@
             </a>
         </svelte:fragment>
     </PageNav>
-    <div class="flex-1 h-screen overflow-y-auto">
+    <div class="flex-1 min-h-screen md:h-screen overflow-y-auto">
         <slot />
     </div>
 </div>

--- a/apps/client/src/routes/tag/[id]/[name]/index.svelte
+++ b/apps/client/src/routes/tag/[id]/[name]/index.svelte
@@ -102,7 +102,7 @@
     {/if}
 </svelte:head>
 
-<div class="w-full h-screen overflow-y-auto">
+<div class="w-full min-h-screen md:h-screen overflow-y-auto">
     {#if tagsTree}
         <div class="tag-header py-6">
             <div class="w-11/12 mx-auto">

--- a/apps/client/src/routes/tag/[id]/[name]/index.svelte
+++ b/apps/client/src/routes/tag/[id]/[name]/index.svelte
@@ -102,7 +102,7 @@
     {/if}
 </svelte:head>
 
-<div class="w-full h-[calc(100vh-51px)] md:h-screen overflow-y-auto">
+<div class="w-full h-screen overflow-y-auto">
     {#if tagsTree}
         <div class="tag-header py-6">
             <div class="w-11/12 mx-auto">

--- a/apps/client/src/themes.scss
+++ b/apps/client/src/themes.scss
@@ -4,6 +4,7 @@
   --accent: rgb(205, 86, 84);
   --accent-dark: rgb(133, 56, 54);
   --accent-light: rgb(221, 142, 142);
+  --accent-transparent: rgb(205, 86, 84, 0.2);
   @apply transition-all;
 }
 
@@ -11,6 +12,7 @@
   --accent: rgb(98, 150, 209);
   --accent-dark: rgb(64, 98, 136);
   --accent-light: rgb(152, 187, 224);
+  --accent-transparent: rgb(98, 150, 209, 0.2);
   @apply transition-all;
 }
 
@@ -18,6 +20,7 @@
   --accent: rgb(145, 82, 169);
   --accent-dark: rgb(95, 53, 110);
   --accent-light: rgb(183, 142, 198);
+  --accent-transparent: rgb(145, 82, 169, 0.2);
   @apply transition-all;
 }
 
@@ -25,6 +28,7 @@
   --accent: rgb(204, 118, 60);
   --accent-dark: rgb(133, 77, 38);
   --accent-light: rgb(222, 165, 123);
+  --accent-transparent: rgb(204, 118, 60, 0.2);
   @apply transition-all;
 }
 
@@ -32,6 +36,7 @@
   --accent: rgb(79, 126, 53);
   --accent-dark: rgb(50, 82, 34);
   --accent-light: rgb(137, 171, 121);
+  --accent-transparent: rgb(79, 126, 53, 0.2);
   @apply transition-all;
 }
 


### PR DESCRIPTION
- Creates two \<main\>s for desktop and mobile
- Splits mobile navbar code into its own class
- Makes mobile navbar an absolute element rather than relative, so it doesn't push anything down
- Removes logo from mobile nav
- Fixes issue where elements covered by it could not be clicked
- Switches all uses of h-[calc(100vh-51px)] to just h-screen; these adjustments were previously made to handle nav bar at top

Note that this is not a final design. To dos are:
- Add logo to tops of pages on mobile, due to removal of logo from mobile nav
- Make the menu exit button separate from the open button on mobile, and don't display mobile nav when menu is open
- Handle issue where menu buttons blend into site elements and background, perhaps by giving each button a circular background with the site theme

![image](https://user-images.githubusercontent.com/71996084/189506440-562064b3-c216-40da-89c2-47dd5906d55f.png)
![image](https://user-images.githubusercontent.com/71996084/189506467-ffeb1506-5df4-40b4-a2b9-c5f2a7eba0c8.png)

Update 9-10-22 6:38 PM:
- Also includes commits aimed at fixing issue where address bar isn't dismissed when scroll down, and bottom of the screen is cut off
- I was able to fix that, but this breaks the mobile menu

Update 10-1-22 6:44 PM
- Fixes issue with address bar not disappearing on most pages
- Adds backgrounds to floating buttons
- Adds scrolling header to every mobile page
- Has mobile menu not cover entire screen, to match desktop version

![image](https://user-images.githubusercontent.com/71996084/193434354-a2c35357-a844-41dd-be0e-07ebf98c3a2f.png)
![image](https://user-images.githubusercontent.com/71996084/193434327-9cd2bf1a-ac88-4d50-a0dc-7fe56f0268c6.png)

- There is still an issue with section page scrolling that will be addressed separately
- There are existing UI issues with some pages on mobile, such as user profile